### PR TITLE
SystemUI: improve blur layer behavior on lockscreen

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -3497,7 +3497,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     private void addStatusBarWindow() {
         makeStatusBarView();
         mStatusBarWindow.addContent(mStatusBarWindowContent);
-        mStatusBarWindowManager = new StatusBarWindowManager(mContext, this);
+        mStatusBarWindowManager = new StatusBarWindowManager(mContext, mKeyguardMonitor);
         mStatusBarWindowManager.add(mStatusBarWindow, getStatusBarHeight());
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -158,7 +158,6 @@ public class StatusBarKeyguardViewManager {
 
     public void onScreenTurnedOn(final IKeyguardShowCallback callback) {
         mScreenOn = true;
-        mStatusBarWindowManager.onScreenTurnedOn();
         mPhoneStatusBar.onScreenTurnedOn();
         if (callback != null) {
             callbackAfterDraw(callback);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
@@ -35,11 +35,12 @@ import com.android.internal.policy.PolicyManager;
 import com.android.keyguard.R;
 import com.android.systemui.statusbar.BaseStatusBar;
 import com.android.systemui.statusbar.StatusBarState;
+import com.android.systemui.statusbar.policy.KeyguardMonitor;
 
 /**
  * Encapsulates all logic for the status bar window state management.
  */
-public class StatusBarWindowManager {
+public class StatusBarWindowManager implements KeyguardMonitor.Callback {
 
     private final Context mContext;
     private final WindowManager mWindowManager;
@@ -54,18 +55,20 @@ public class StatusBarWindowManager {
     private final SurfaceSession mFxSession;
     private final WindowManagerPolicy mPolicy = PolicyManager.makeNewWindowManager();
 
-    private final PhoneStatusBar mBar;
+    private final KeyguardMonitor mKeyguardMonitor;
 
     private static final int TYPE_LAYER_MULTIPLIER = 10000; // refer to WindowManagerService.TYPE_LAYER_MULTIPLIER
     private static final int TYPE_LAYER_OFFSET = 1000;      // refer to WindowManagerService.TYPE_LAYER_OFFSET
 
     private final State mCurrentState = new State();
 
-    public StatusBarWindowManager(Context context, PhoneStatusBar bar) {
+    public StatusBarWindowManager(Context context, KeyguardMonitor kgm) {
         mContext = context;
         mWindowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
         mKeyguardScreenRotation = shouldEnableKeyguardScreenRotation();
-        mBar = bar;
+
+        mKeyguardMonitor = kgm;
+        mKeyguardMonitor.addCallback(this);
 
         mKeyguardBlurEnabled = mContext.getResources().getBoolean(
                 com.android.internal.R.bool.config_ui_blur_enabled);
@@ -208,7 +211,8 @@ public class StatusBarWindowManager {
 
     private void applyKeyguardBlurShow(){
         boolean isblur = false;
-        if (mCurrentState.keyguardShowing && mKeyguardBlurEnabled && !mCurrentState.keyguardOccluded) {
+        if (mCurrentState.keyguardShowing && mKeyguardBlurEnabled
+                && !mCurrentState.keyguardOccluded) {
             isblur = true;
         }
         if (mKeyguardBlur != null) {
@@ -223,10 +227,6 @@ public class StatusBarWindowManager {
     public void setKeyguardShowing(boolean showing) {
         mCurrentState.keyguardShowing = showing;
         apply(mCurrentState);
-    }
-
-    void onScreenTurnedOn(){
-        applyKeyguardBlurShow();
     }
 
     public void setKeyguardOccluded(boolean occluded) {
@@ -276,7 +276,7 @@ public class StatusBarWindowManager {
 
     void setBlur(float b){
         if (mKeyguardBlurEnabled && mKeyguardBlur != null) {
-            float minBlur = mBar.isSecure() ? 1.0f : 0.0f;
+            float minBlur = mKeyguardMonitor.isSecure() ? 1.0f : 0.0f;
             if (b < minBlur) {
                 b = minBlur;
             } else if (b > 1.0f) {
@@ -292,6 +292,11 @@ public class StatusBarWindowManager {
     public void setStatusBarState(int state) {
         mCurrentState.statusBarState = state;
         apply(mCurrentState);
+    }
+
+    @Override
+    public void onKeyguardChanged() {
+        applyKeyguardBlurShow();
     }
 
     private static class State {


### PR DESCRIPTION
If the lockscreen is toggled on and off via the update monitor,
we need to reset the blur properly

Change-Id: I7dc39035bd9dca7fd04de60802be07ca1b53ca34
Signed-off-by: Roman Birg <roman@cyngn.com>